### PR TITLE
Check if the cache exists before creating it.

### DIFF
--- a/angular-briefcache.js
+++ b/angular-briefcache.js
@@ -1,7 +1,7 @@
 angular.module('banno.briefCache', ['angular-cache']).factory('briefCache', ['CacheFactory', function(CacheFactory) {
 	'use strict';
 	/* jshint newcap:false */
-	return CacheFactory('briefCache', {
+	return CacheFactory.get('briefCache') || CacheFactory('briefCache', {
 		maxAge: 10 * 1000, // expire after 10 secs
 		cacheFlushInterval: 60 * 60 * 1000, // clear itself every hour
 		deleteOnExpire: 'passive' // delete as they are requested


### PR DESCRIPTION
We need to check if the cache exists first, otherwise `angular-cache` will complain.

I couldn't figure out how to write a test against this, but it definitely breaks the unit tests in https://github.com/Banno/angular-platform-services when RequireJS is used there.
